### PR TITLE
feat: migrate XRD group from demo.openportal.dev to openportal.dev

### DIFF
--- a/composition.yaml
+++ b/composition.yaml
@@ -10,7 +10,7 @@ metadata:
     provider: composite
 spec:
   compositeTypeRef:
-    apiVersion: demo.openportal.dev/v1alpha1
+    apiVersion: openportal.dev/v1alpha1
     kind: WhoAmIService
   
   mode: Pipeline
@@ -45,7 +45,7 @@ spec:
           {{- $xrName := .observed.composite.resource.metadata.name }}
           
           # Create WhoAmI XR (reuses existing template-whoami)
-          apiVersion: demo.openportal.dev/v1alpha1
+          apiVersion: openportal.dev/v1alpha1
           kind: WhoAmIApp
           metadata:
             name: {{ $xrName }}-app

--- a/examples/basic.yaml
+++ b/examples/basic.yaml
@@ -1,11 +1,11 @@
 # Basic WhoAmIService Example
 # Creates a simple whoami app with automatic DNS configuration
-apiVersion: demo.openportal.dev/v1alpha1
+apiVersion: openportal.dev/v1alpha1
 kind: WhoAmIService
 metadata:
   name: demo-service
 spec:
-  name: demo  # Will create demo.openportal.dev (or configured zone)
+  name: demo  # Will create openportal.dev (or configured zone)
   # All other parameters use defaults:
   # - replicas: 1
   # - image: traefik/whoami:v1.10.1

--- a/examples/production.yaml
+++ b/examples/production.yaml
@@ -1,6 +1,6 @@
 # Production WhoAmIService Example
 # Full configuration with custom settings
-apiVersion: demo.openportal.dev/v1alpha1
+apiVersion: openportal.dev/v1alpha1
 kind: WhoAmIService
 metadata:
   name: prod-app-service

--- a/xrd.yaml
+++ b/xrd.yaml
@@ -4,7 +4,7 @@
 apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
-  name: whoamiservices.demo.openportal.dev
+  name: whoamiservices.openportal.dev
   labels:
     terasky.backstage.io/generate-form: "true"
   annotations:
@@ -18,7 +18,7 @@ metadata:
     terasky.backstage.io/dependsOn: 'Component:template-whoami,Component:template-cloudflare-dnsrecord'
 spec:
   scope: Namespaced  # Crossplane v2 - XRs can be created in any namespace
-  group: demo.openportal.dev
+  group: openportal.dev
   names:
     kind: WhoAmIService
     plural: whoamiservices


### PR DESCRIPTION
## Summary
- Migrate XRD group from `demo.openportal.dev` to `openportal.dev` for consistency
- Remove "demo" subdomain from all API versions

## Changes
- Updated XRD name from `whoamiservices.demo.openportal.dev` to `whoamiservices.openportal.dev`
- Updated group from `demo.openportal.dev` to `openportal.dev`
- Updated all apiVersion references from `demo.openportal.dev/v1alpha1` to `openportal.dev/v1alpha1`

## Benefits
- Consistent domain naming across all templates
- Removes unnecessary "demo" subdomain
- Better reflects production readiness