### PR TITLE
fix: add namespace to WhoAmIApp XR creation

### DIFF
--- a/composition.yaml
+++ b/composition.yaml
@@ -43,12 +43,14 @@ spec:
           {{- $replicas := .observed.composite.resource.spec.replicas | default 1 }}
           {{- $image := .observed.composite.resource.spec.image | default "traefik/whoami:v1.10.1" }}
           {{- $xrName := .observed.composite.resource.metadata.name }}
+          {{- $xrNamespace := .observed.composite.resource.metadata.namespace }}
           
           # Create WhoAmI XR (reuses existing template-whoami)
           apiVersion: openportal.dev/v1alpha1
           kind: WhoAmIApp
           metadata:
             name: {{ $xrName }}-app
+            namespace: {{ $xrNamespace }}
             annotations:
               gotemplating.fn.crossplane.io/composition-resource-name: whoami-app
               gotemplating.fn.crossplane.io/ready: "True"


### PR DESCRIPTION
## Summary
- Add namespace specification when creating child XRs from parent XR
- Ensures proper namespace scoping for composition-of-compositions pattern

## Problem
When a namespaced XR creates other namespaced XRs, it must specify the namespace. Without this, the child XR creation could fail or be created in an unexpected location.

## Solution
- Added `$xrNamespace` variable to capture parent XR's namespace
- Specified `namespace: {{ $xrNamespace }}` in the WhoAmIApp XR metadata

## Testing
- [ ] Deploy updated composition
- [ ] Create WhoAmIService XR in a namespace
- [ ] Verify child WhoAmIApp XR is created in same namespace
- [ ] Check both XRs reconcile successfully

## Related
Part of the fix for namespaced XR patterns across all templates.
See also: open-service-portal/template-whoami#5