### PR TITLE
fix: correct Backstage dependency references in XRD

### DIFF
--- a/configuration/xrd.yaml
+++ b/configuration/xrd.yaml
@@ -18,7 +18,7 @@ metadata:
     terasky.backstage.io/system: 'infrastructure-templates'
     terasky.backstage.io/component-type: 'crossplane-template'
     terasky.backstage.io/lifecycle: 'production'
-    terasky.backstage.io/dependsOn: 'Component:template-whoami,Component:template-cloudflare-dnsrecord'
+    terasky.backstage.io/dependsOn: 'template:default/whoamiapps.openportal.dev-v1alpha1,template:default/dnsrecords.openportal.dev-v1alpha1'
 spec:
   scope: Namespaced  # Crossplane v2 - XRs can be created in any namespace
   group: openportal.dev


### PR DESCRIPTION
## Summary
This PR fixes the Backstage dependency references in the WhoAmIService XRD to use correct entity references that match the actual template names in the Backstage catalog.

## Problem
The `terasky.backstage.io/dependsOn` annotation was using GitHub repository names instead of the actual Backstage entity references, causing the dependencies not to appear in the catalog graph relations.

## Solution
Updated the annotation to use the correct Backstage entity format:
- `template:default/whoamiapps.openportal.dev-v1alpha1` (for whoami app template)
- `template:default/dnsrecords.openportal.dev-v1alpha1` (for DNS record template)

## Changes
- Modified `configuration/xrd.yaml` to fix the `terasky.backstage.io/dependsOn` annotation

## Testing
After this change is deployed:
1. The template will be re-ingested by the Kubernetes Ingestor
2. Dependencies should appear in the `relations` field of the API response
3. The catalog graph view should properly show the dependency connections

## Related Links
- Catalog Graph View: http://localhost:3000/catalog-graph?rootEntityRefs%5B%5D=template%3Adefault%2Fwhoamiservices.openportal.dev-v1alpha1