### PR TITLE
fix: use ingress controller public IP from environment config for DNS records

### DIFF
--- a/configuration/composition.yaml
+++ b/configuration/composition.yaml
@@ -81,24 +81,11 @@ spec:
           {{- $xrName := .observed.composite.resource.metadata.name }}
           {{- $xrNamespace := .observed.composite.resource.metadata.namespace }}
           
-          {{/* Get the domain from environment config */}}
+          {{/* Get the domain and ingress IP from environment config */}}
           {{- $envZone := index .context "apiextensions.crossplane.io/environment" "zone" | default "localhost" }}
+          {{- $ingressIP := index .context "apiextensions.crossplane.io/environment" "ingressIP" | default "" }}
           
-          {{/* Try to get the Ingress IP from the app - this will be available after auto-ready */}}
-          {{- $ingressIP := "" }}
-          {{- range .observed.resources }}
-            {{- if eq .resource.kind "Object" }}
-              {{- if .resource.spec.forProvider.manifest }}
-                {{- if eq .resource.spec.forProvider.manifest.kind "Ingress" }}
-                  {{- if .resource.status.atProvider.manifest.status.loadBalancer.ingress }}
-                    {{- $ingressIP = (index .resource.status.atProvider.manifest.status.loadBalancer.ingress 0).ip | default "" }}
-                  {{- end }}
-                {{- end }}
-              {{- end }}
-            {{- end }}
-          {{- end }}
-          
-          {{/* Default to a placeholder IP if we can't get the real one yet */}}
+          {{/* If no ingress IP in environment, use default */}}
           {{- if not $ingressIP }}
             {{- $ingressIP = "192.168.1.100" }}
           {{- end }}
@@ -156,6 +143,10 @@ spec:
                     {{- $dnsReady = true }}
                   {{- end }}
                 {{- end }}
+              {{- end }}
+              {{/* Also extract the IP from the DNS record */}}
+              {{- if .resource.spec.value }}
+                {{- $ingressIP = .resource.spec.value }}
               {{- end }}
             {{- end }}
           {{- end }}


### PR DESCRIPTION
## Summary

This PR fixes the DNS record creation to use the correct public IP address instead of a hardcoded local IP.

## Problem

The WhoAmI service was creating DNS records pointing to a local IP address (`192.168.1.100`) instead of the actual public IP of the ingress controller (`50.56.157.82`). This prevented external access to services via their DNS names.

## Root Cause

The composition attempted to extract the ingress IP from nested Object resources created by the WhoAmIApp child XR. However, due to Crossplane's resource visibility scope, parent compositions can only see their direct child XRs, not the resources those children create.

## Solution

- **Simplified IP retrieval**: Removed complex nested resource extraction logic
- **Centralized configuration**: Added the ingress controller's public IP to the `dns-config` EnvironmentConfig
- **Updated composition**: Modified to read `ingressIP` from the environment configuration

## Changes

- Updated `configuration/composition.yaml` to retrieve ingress IP from EnvironmentConfig
- Removed unreliable nested resource scanning logic
- Maintains fallback to `192.168.1.100` if no IP is configured

## Testing

1. Applied the updated composition
2. Recreated the WhoAmIService XR
3. Verified DNS record now contains correct public IP: `50.56.157.82`
4. Confirmed DNS resolution: `nslookup whoami.openportal.dev` returns the public IP

## Impact

This change ensures that all services created through the WhoAmI service template will have DNS records pointing to the publicly accessible ingress controller IP, enabling proper external access.

## Note for Deployment

After merging, clusters need to update their `dns-config` EnvironmentConfig to include the `ingressIP` field:

```bash
kubectl patch environmentconfig dns-config --type merge -p '{"data": {"ingressIP": "YOUR_INGRESS_IP"}}'
```